### PR TITLE
pastebin.d: Add dpaste.org support

### DIFF
--- a/pastebin.d/dpaste.org.conf
+++ b/pastebin.d/dpaste.org.conf
@@ -1,0 +1,17 @@
+[pastebin]
+basename = dpaste.org
+https = True
+paste_regexp = (.*)
+post_page = api/
+
+[format]
+content = content
+format = lexer
+expires = expires
+response_format = format
+
+[defaults]
+format = _code
+# Keep it for one month.
+expires = 2592000
+response_format = url


### PR DESCRIPTION
It's a free and open source pastebin: https://dpaste.org/about/

API is described at https://docs.dpaste.org/api/#postapi