### PR TITLE
[bug]: fixed can not find config file while not in project root directory

### DIFF
--- a/pastebinit
+++ b/pastebinit
@@ -80,7 +80,10 @@ def preloadPastebins():
             + ['/etc', '/usr/local/etc',
                os.environ.get('XDG_CONFIG_HOME',
                    os.path.expanduser('~/.config')),
-               os.path.expanduser('~/.pastebin.d')]:
+               os.path.expanduser('~/.pastebin.d'),
+               os.path.join(
+                    os.path.dirname(
+                    os.path.realpath(__file__)), 'pastebin.d')]:
 
         confdir = confdir.rstrip('/')
         if not confdir.endswith('pastebin.d'):


### PR DESCRIPTION
bug:
```bash
(venv) root@user-VirtualBox:~/# python3 ./common/pastebinit-1.7.0/pastebinit  -l
Supported pastebins:
(venv) root@user-VirtualBox:~/# cd common/pastebinit-1.7.0/
(venv) root@user-VirtualBox:~//common/pastebinit-1.7.0# python3 pastebinit -l
Supported pastebins:
- bpa.st
- dpaste.com
- dpaste.org
- p.defau.lt
- paste.centos.org
- paste.debian.net
- paste.opendev.org
- paste.ubuntu.com
- paste.ubuntu.org.cn
- paste2.org
- pastebin.com
- sprunge.us
```
